### PR TITLE
chore(maintenance): add license field to packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "license": "MIT-0",
       "workspaces": [
         "packages/reporting",
         "packages/testing",
@@ -2756,13 +2757,17 @@
     },
     "packages/github": {
       "version": "1.0.0",
+      "license": "MIT-0",
       "devDependencies": {}
     },
     "packages/reporting": {
+      "version": "1.0.0",
+      "license": "MIT-0",
       "devDependencies": {}
     },
     "packages/testing": {
       "version": "1.0.0",
+      "license": "MIT-0",
       "devDependencies": {}
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/testing",
     "packages/github"
   ],
+  "license": "MIT-0",
   "devDependencies": {
     "@anatine/zod-mock": "^3.13.4",
     "@biomejs/biome": "1.6.4",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -2,5 +2,6 @@
 	"name": "github",
 	"version": "1.0.0",
 	"description": "Powertools GitHub client",
+	"license": "MIT-0",
 	"devDependencies": {}
 }

--- a/packages/reporting/package.json
+++ b/packages/reporting/package.json
@@ -1,7 +1,9 @@
 {
 	"name": "reporting",
+	"version": "1.0.0",
 	"private": true,
 	"type": "module",
 	"main": "index.js",
+	"license": "MIT-0",
 	"devDependencies": {}
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "testing",
 	"version": "1.0.0",
+	"license": "MIT-0",
 	"description": "tooling to build fake data, network interceptors, etc.",
 	"devDependencies": {}
 }


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:* This PR adds a `license` field to all the `package.json` files and the corresponding entries in the `package-lock.json`. While doing this, I also added a `version` field that was missing in the `reporting` package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
