### PR TITLE
fix: update gh cli command to check for label

### DIFF
--- a/.github/actions/create-pr/create_pr_for_staged_changes.sh
+++ b/.github/actions/create-pr/create_pr_for_staged_changes.sh
@@ -4,12 +4,10 @@ set -uo pipefail # prevent accessing unset env vars, prevent masking pipeline er
 #docs
 #title              :create_pr_for_staged_changes.sh
 #description        :This script will create a PR for staged changes, detect and close duplicate PRs. All PRs will be omitted from Release Notes and Changelogs
-#author		        :@heitorlessa
-#date               :May 8th 2023
-#version            :0.1
-#usage		        :bash create_pr_for_staged_changes.sh {git_staged_files_or_directories_separated_by_space}
+#author		        :Amazon Web Services
+#version            :1.0
+#usage		        :bash create_pr_for_staged_changes.sh
 #notes              :Meant to use in GitHub Actions only. Temporary branch will be named $TEMP_BRANCH_PREFIX-$GITHUB_RUN_ID
-#os_version         :Ubuntu 22.04.2 LTS
 #required_env_vars  :PR_TITLE, TEMP_BRANCH_PREFIX, GH_TOKEN
 #==============================================================================
 
@@ -88,7 +86,7 @@ function create_temporary_branch_with_changes() {
 
 function create_label_if_not_exists() {
     start_span "Creating label if it does not exist"
-    LABEL_EXISTS=$(gh label list --json name --jq ".[] | select(.name == \"${SKIP_LABEL}\") | .name")
+    LABEL_EXISTS=$(gh label list --search $SKIP_LABEL --json name --jq ".[] | select(.name == \"${SKIP_LABEL}\") | .name")
 
     if [ -z "${LABEL_EXISTS}" ]; then
         debug "Creating label: ${SKIP_LABEL}"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This pull request updates the `create_pr_for_staged_changes.sh` script part of the `version-n-changelog` GitHub Action so that the `gh label list` command used to query labels from the repo uses the `--search` flag to narrow down the list of labels returned, and avoid pagination issues.

This should ensure that the label is found regardless of the amount of labels present in the repo.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #188

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/actions/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/actions/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.