### PR TITLE
fix: pass release type flag correctly

### DIFF
--- a/.github/actions/version-n-changelog/action.yml
+++ b/.github/actions/version-n-changelog/action.yml
@@ -34,7 +34,7 @@ runs:
         
         # Add release-type only if specified
         if [[ -n "${{ inputs.release-type }}" ]]; then
-          CMD_ARGS="${{ inputs.release-type }}"
+          CMD_ARGS="--type ${{ inputs.release-type }}"
         fi
         
         # Add dry-run flag if enabled
@@ -44,6 +44,11 @@ runs:
           else
             CMD_ARGS="--dry-run"
           fi
+        fi
+
+        # Add verbose flag if GitHub Actions is running with debug logging enabled
+        if [[ -n "${{ secrets.ACTIONS_RUNNER_DEBUG }}" ]]; then
+          CMD_ARGS="$CMD_ARGS --verbose"
         fi
         
         # Run bump-n-go with the constructed arguments

--- a/.gitignore
+++ b/.gitignore
@@ -443,3 +443,6 @@ pyrightconfig.json
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/python,node,intellij,visualstudiocode
+
+*.local.md
+.amazonq/


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR fixes a bug that caused the `release-type` input to be ignored by improving the logic that detects it and passes it as a flag to the CLI.

The PR also adds new logic to detect when the GitHub Action is [running in debug mode](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging) and enable verbose logging in the CLI.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #192

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/actions/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/actions/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.