### PR TITLE
fix: set debug using env variable in version-n-changelog

### DIFF
--- a/.github/actions/version-n-changelog/action.yml
+++ b/.github/actions/version-n-changelog/action.yml
@@ -33,8 +33,8 @@ runs:
         CMD_ARGS=""
         
         # Add release-type only if specified
-        if [[ -n "${{ inputs.release-type }}" ]]; then
-          CMD_ARGS="--type ${{ inputs.release-type }}"
+          if [[ -n "${{ inputs.release-type }}" && "${{ inputs.release-type }}" != "auto" ]]; then
+            CMD_ARGS="--type ${{ inputs.release-type }}"
         fi
         
         # Add dry-run flag if enabled

--- a/.github/actions/version-n-changelog/action.yml
+++ b/.github/actions/version-n-changelog/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
         # Add verbose flag if GitHub Actions is running with debug logging enabled
-          if [[ -n "$RUNNER_DEBUG" ]]; then
+        if [[ -n "$RUNNER_DEBUG" ]]; then
             CMD_ARGS="$CMD_ARGS --verbose"
         fi
         

--- a/.github/actions/version-n-changelog/action.yml
+++ b/.github/actions/version-n-changelog/action.yml
@@ -47,8 +47,8 @@ runs:
         fi
 
         # Add verbose flag if GitHub Actions is running with debug logging enabled
-        if [[ -n "${{ secrets.ACTIONS_RUNNER_DEBUG }}" ]]; then
-          CMD_ARGS="$CMD_ARGS --verbose"
+          if [[ -n "$RUNNER_DEBUG" ]]; then
+            CMD_ARGS="$CMD_ARGS --verbose"
         fi
         
         # Run bump-n-go with the constructed arguments

--- a/.github/actions/version-n-changelog/action.yml
+++ b/.github/actions/version-n-changelog/action.yml
@@ -33,7 +33,7 @@ runs:
         CMD_ARGS=""
         
         # Add release-type only if specified
-          if [[ -n "${{ inputs.release-type }}" && "${{ inputs.release-type }}" != "auto" ]]; then
+        if [[ -n "${{ inputs.release-type }}" && "${{ inputs.release-type }}" != "auto" ]]; then
             CMD_ARGS="--type ${{ inputs.release-type }}"
         fi
         


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes the usage of the `secrets.*` from the `version-n-changelog` action in favor of using an alternative environment variable to set log verbosity.

The PR also adds a special handling case for when the version type is set to `auto` (default).

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #197

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/actions/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/actions/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.